### PR TITLE
Update open source license meta data in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     classifiers=[
         "Development Status :: 2 - Pre-Alpha",
         "Intended Audience :: Developers",
-        "License :: OSI Approved :: Apache Software License",
+        "License :: OSI Approved :: MIT License",
         "Natural Language :: English",
         "Programming Language :: Python :: 3.5",
         "Topic :: Multimedia :: Graphics :: 3D Rendering"


### PR DESCRIPTION
Switch from Apache License to MIT License in the below commit

```
  commit 280c86a5dc42e79d7a950a5e72eb2acb741ffe48
  Author: Jean-Sebastien Bevilacqua <realitix@gmail.com>
  Date:   Mon Nov 21 17:53:32 2016 +0100

      Restarting on new bases with only full Vulkan support
```