### PR TITLE
Fix pylint warning on Matrix4.to_look_at() usage in vulk.graphic.camera

### DIFF
--- a/vulk/graphic/camera.py
+++ b/vulk/graphic/camera.py
@@ -35,7 +35,6 @@ class PerspectiveCamera(Camera):
         aspect = self.viewport_width / self.viewport_height
         self.projection.to_projection(abs(self.near), abs(self.far),
                                       self.fov, aspect)
-        self.view.to_look_at(self.position,
-                             Vector3().set(self.position).add(self.direction),
+        self.view.to_look_at(Vector3().set(self.position).add(self.direction),
                              self.up)
         self.combined.set(self.projection).mul(self.view)


### PR DESCRIPTION
************* Module vulk.graphic.camera
E: 38, 8: Too many positional arguments for method call (too-many-function-args)