### PR TITLE
Fix pylint warning no-value-for-parameter on HighPerformanceImage()._manage_commandbuffer()

### DIFF
--- a/vulk/vulkanobject.py
+++ b/vulk/vulkanobject.py
@@ -931,21 +931,21 @@ class HighPerformanceImage():
             context, context.queue_family_indices['graphic'], 0)
 
         # Transition the staging image to optimal source transfert layout
-        with self._manage_commandbuffer(commandpool) as cb:
+        with self._manage_commandbuffer(context, commandpool) as cb:
             self.staging_image.update_layout(
                 cb, 'VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL')
 
         # Transition the final image to optimal destination transfert layout
-        with self._manage_commandbuffer(commandpool) as cb:
+        with self._manage_commandbuffer(context, commandpool) as cb:
             self.texture_image.update_layout(
                 cb, 'VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL')
 
         # Copy staging image into final image
-        with self._manage_commandbuffer(commandpool) as cb:
+        with self._manage_commandbuffer(context, commandpool) as cb:
             self.staging_image.copy_to(cb, self.texture_image)
 
         # Set the best layout for the final image
-        with self._manage_commandbuffer(commandpool) as cb:
+        with self._manage_commandbuffer(context, commandpool) as cb:
             self.texture_image.update_layout(
                 cb, 'VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL')
 


### PR DESCRIPTION
************* Module vulk.vulkanobject
E:934,13: No value for argument 'commandpool' in method call (no-value-for-parameter)
E:939,13: No value for argument 'commandpool' in method call (no-value-for-parameter)
E:944,13: No value for argument 'commandpool' in method call (no-value-for-parameter)
E:948,13: No value for argument 'commandpool' in method call (no-value-for-parameter)