### PR TITLE
Fix usefulness of pylint on Travis-CI

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,3 +1,8 @@
 [MASTER]
 ignore=tests
 disable=R,C
+
+# A comma-separated list of package or module names from where C extensions may
+# be loaded. Extensions are loading into the active Python interpreter and may
+# run arbitrary code
+extension-pkg-whitelist=vulkan

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ install:
 script:
 #- py.test .
   - flake8 vulk
-#- pylint vulk
+  - pylint vulk
 
 deploy:
   provider: script

--- a/vulk/baseapp.py
+++ b/vulk/baseapp.py
@@ -40,6 +40,8 @@ class BaseApp(ABC):
 
         self.last_time = millis()
         self._init_logger()
+        self.context = None
+        self.window = None
 
     def _init_logger(self):
         logger = logging.getLogger()

--- a/vulk/context.py
+++ b/vulk/context.py
@@ -67,8 +67,8 @@ class VulkWindow():
             logger.critical(msg)
             raise SDL2Error(msg)
 
-        logger.debug("SDL2 window opened with configuration: %s"
-                     % (configuration,))
+        logger.debug("SDL2 window opened with configuration: %s",
+                     (configuration,))
 
         self.info = sdl2.SDL_SysWMinfo()
         sdl2.SDL_VERSION(self.info.version)
@@ -140,7 +140,7 @@ class VulkContext():
         available_extensions = [
             e.extensionName
             for e in vk.vkEnumerateInstanceExtensionProperties(None)]
-        logger.debug("Available instance extensions: %s" %
+        logger.debug("Available instance extensions: %s",
                      available_extensions)
 
         # Compute needed extensions
@@ -196,7 +196,7 @@ class VulkContext():
         available_extensions = [
             e.extensionName for e in vk.vkEnumerateDeviceExtensionProperties(
                 physical_device, None)]
-        logger.debug("Available device extensions: %s" % available_extensions)
+        logger.debug("Available device extensions: %s", available_extensions)
 
         # Select extensions
         enabled_extensions = []
@@ -230,7 +230,7 @@ class VulkContext():
 
         layers = [l.layerName for l in
                   vk.vkEnumerateInstanceLayerProperties(None)]
-        logger.debug("Available layers: %s" % layers)
+        logger.debug("Available layers: %s", layers)
 
         # Standard validation is a meta layer containing the others
         standard = 'VK_LAYER_LUNARG_standard_validation'
@@ -378,7 +378,7 @@ class VulkContext():
         }
 
         def debug_function(*args):
-            logger.log(vulkan_debug_mapping[args[0]], "VULKAN: %s" % args[6])
+            logger.log(vulkan_debug_mapping[args[0]], "VULKAN: %s", args[6])
 
         flags = (vk.VK_DEBUG_REPORT_ERROR_BIT_EXT |
                  vk.VK_DEBUG_REPORT_WARNING_BIT_EXT |
@@ -474,7 +474,7 @@ class VulkContext():
         properties = [vk.vkGetPhysicalDeviceProperties(p)
                       for p in physical_devices]
 
-        logger.debug("Available physical devices: %s" %
+        logger.debug("Available physical devices: %s",
                      [p.deviceName for p in properties])
 
         # Select best physical device based on properties ans features
@@ -512,8 +512,8 @@ class VulkContext():
         self.physical_device_properties = properties[selected_index]
         self.physical_device_features = features[selected_index]
 
-        logger.debug("%s device selected"
-                     % self.physical_device_properties.deviceName)
+        logger.debug("%s device selected",
+                     self.physical_device_properties.deviceName)
 
     def _create_device(self, configuration):
         '''Create Vulkan logical device

--- a/vulk/context.py
+++ b/vulk/context.py
@@ -121,6 +121,8 @@ class VulkContext():
         # Internal semaphores
         self._semaphore_available = None
         self._semaphore_copied = None
+        # Command buffers
+        self.commandbuffers = None
 
     @staticmethod
     def _get_instance_extensions(window, configuration):

--- a/vulk/context.py
+++ b/vulk/context.py
@@ -14,7 +14,7 @@ import ctypes
 import logging
 import sdl2
 import sdl2.ext
-import vulkan as vk
+import vulkan as vk  # pylint: disable=import-error
 
 from vulk.exception import VulkError
 from vulk.vulkanobject import CommandPool, Image, ImageView, \

--- a/vulk/math/matrix.py
+++ b/vulk/math/matrix.py
@@ -146,7 +146,7 @@ class Matrix4(Matrix):
         mb = matrix.values
         m = Matrix4.M
 
-        for key in Matrix4.M.viewkeys():
+        for key in Matrix4.M.keys():
             k0 = key // 10
             k1 = key % 10
             tmp.values[key] = (ma[m[k0]] * mb[m[k1]] +

--- a/vulk/math/matrix.py
+++ b/vulk/math/matrix.py
@@ -134,9 +134,9 @@ class Matrix4(Matrix):
     def to_translation(self, vector):
         self.idt()
 
-        self.values[Matrix4.M03] = vector.x
-        self.values[Matrix4.M13] = vector.y
-        self.values[Matrix4.M23] = vector.z
+        self.values[Matrix4.M[3]] = vector.x
+        self.values[Matrix4.M[13]] = vector.y
+        self.values[Matrix4.M[23]] = vector.z
 
         return self
 

--- a/vulk/math/vector.py
+++ b/vulk/math/vector.py
@@ -194,15 +194,15 @@ class Vector3(Vector):
         x = self.x
         y = self.y
         z = self.z
-        w = 1 / (x * c[Matrix4.M30] + y * c[Matrix4.M31] +
-                 z * c[Matrix4.M32] + c[Matrix4.M33])
+        w = 1 / (x * c[Matrix4.M[30]] + y * c[Matrix4.M[31]] +
+                 z * c[Matrix4.M[32]] + c[Matrix4.M[33]])
 
-        self.x = (x * c[Matrix4.M00] + y * c[Matrix4.M01] +
-                  z * c[Matrix4.M02] + c[Matrix4.M03]) * w
-        self.y = (x * c[Matrix4.M10] + y * c[Matrix4.M11] +
-                  z * c[Matrix4.M12] + c[Matrix4.M13]) * w
-        self.z = (x * c[Matrix4.M20] + y * c[Matrix4.M21] +
-                  z * c[Matrix4.M22] + c[Matrix4.M23]) * w
+        self.x = (x * c[Matrix4.M[0]] + y * c[Matrix4.M[1]] +
+                  z * c[Matrix4.M[2]] + c[Matrix4.M[3]]) * w
+        self.y = (x * c[Matrix4.M[10]] + y * c[Matrix4.M[11]] +
+                  z * c[Matrix4.M[12]] + c[Matrix4.M[13]]) * w
+        self.z = (x * c[Matrix4.M[20]] + y * c[Matrix4.M[21]] +
+                  z * c[Matrix4.M[22]] + c[Matrix4.M[23]]) * w
 
         return self
 

--- a/vulk/math/vector.py
+++ b/vulk/math/vector.py
@@ -119,6 +119,9 @@ class Vector():
         self.coordinates = value
         return self
 
+    def add(self, value):
+        return self.__add__(value)
+
     def sub(self, value):
         return self.__sub__(value)
 

--- a/vulk/vulkanconstant.py
+++ b/vulk/vulkanconstant.py
@@ -1,7 +1,7 @@
 '''
 This module contains useful mapping or constants
 '''
-import vulkan as vk
+import vulkan as vk  # pylint: disable=import-error
 
 
 # Wow! That was long to do!

--- a/vulk/vulkanobject.py
+++ b/vulk/vulkanobject.py
@@ -17,7 +17,7 @@ module.
 from collections import namedtuple
 from contextlib import contextmanager
 import logging
-import vulkan as vk
+import vulkan as vk  # pylint: disable=import-error
 
 from vulk.exception import VulkError
 from vulk import vulkanconstant


### PR DESCRIPTION
***Not yet ready for merging***

`pylint` was previously reporting numerous false positives on the `vulk` code base.

With the quality of reporting improved from this tool, re-enable `pylint` on Travis-CI.