### PR TITLE
Fix AttributeError: 'Vector2' object has no attribute 'values'

### DIFF
--- a/vulk/math/vector.py
+++ b/vulk/math/vector.py
@@ -67,7 +67,7 @@ class Vector():
         return str(self._values)
 
     def __eq__(self, other):
-        return all(self._values == other.values)
+        return all(self._values == other._values)
 
     def __copy__(self):
         return self.__class__(self._values)


### PR DESCRIPTION
Found when running test suite, e.g. with `python setup.py test`